### PR TITLE
x-data-checker: track latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+[![Flathub](https://img.shields.io/flathub/v/as.may.moat?logo=flathub&logoColor=white&style=for-the-badge)][flathub]
+[![Installs](https://img.shields.io/flathub/downloads/as.may.moat?label=Installs&logo=flathub&logoColor=white&style=for-the-badge)][flathub]
+
+# Flathub manifest for Museum of All Things
+
+- To install the game, visit [Flathub]
+- For the game source code, issue tracking, etc. see [@m4ym4y/museum-of-all-things](https://github.com/m4ym4y/museum-of-all-things)
+
+[flathub]: https://flathub.org/apps/details/as.may.moat

--- a/as.may.moat.yml
+++ b/as.may.moat.yml
@@ -22,13 +22,24 @@ modules:
         url: https://github.com/m4ym4y/museum-of-all-things.git
         tag: v1.0.1
         commit: 27c80a8a96efaa4a31ada0edd45240804a287f1d
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/m4ym4y/museum-of-all-things/releases/latest
+          tag-query: .tag_name
 
       - type: file
         url: https://github.com/m4ym4y/museum-of-all-things/releases/download/v1.0.1/MuseumOfAllThings.pck
         sha256: 631ad04d2f16e3cb9506397df135ffa1a8a5757261026a2ead875810a5134926
+        dest-filename: godot-runner.pck
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/m4ym4y/museum-of-all-things/releases/latest
+          version-query: .tag_name
+          url-query: '"https://github.com/m4ym4y/museum-of-all-things/releases/download/"
+            + $version + "/MuseumOfAllThings.pck"'
 
     build-commands:
-      - install -Dm644 MuseumOfAllThings.pck ${FLATPAK_DEST}/bin/godot-runner.pck
+      - install -Dm644 godot-runner.pck ${FLATPAK_DEST}/bin/godot-runner.pck
       - install -Dm644 linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 linux/${FLATPAK_ID}.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
       - install -Dm644 assets/logo/moat_logo_small.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png


### PR DESCRIPTION
This should get us automatic PR from @flathubbot any time there's a new upstream release, meaning the release process is simplified to testing the Flathub-built Flatpak on that PR and then merging it if it works.

I also added a simple README as long as I was here.